### PR TITLE
"dydt(uyind)=desired_duy" instead of "desired_uy"

### DIFF
--- a/ode_comp_tau_dot_perfect_measurements.m
+++ b/ode_comp_tau_dot_perfect_measurements.m
@@ -28,7 +28,7 @@ desired_dux = desired_ux - state(uxind);
 dydt(uxind) = desired_dux;
 desired_uy = 0; %parameters.K_ventral * (observations(omega_y_ind)- parameters.ref_omega_y);
 desired_duy = desired_uy - state(uyind);
-dydt(uyind) = desired_uy;
+dydt(uyind) = desired_duy;
 
 % z-axis dynamics / control:
 uz = get_thrust_perfect_measurements(state, parameters);

--- a/ode_comp_tau_dot_perfect_measurements_ZOH.m
+++ b/ode_comp_tau_dot_perfect_measurements_ZOH.m
@@ -29,7 +29,7 @@ desired_dux = desired_ux - state(uxind);
 dydt(uxind) = desired_dux;
 desired_uy = 0; %parameters.K_ventral * (observations(omega_y_ind)- parameters.ref_omega_y);
 desired_duy = desired_uy - state(uyind);
-dydt(uyind) = desired_uy;
+dydt(uyind) = desired_duy;
 
 % z-axis dynamics / control:
 % omega_z = -state(vzind) / state(zind);

--- a/ode_comp_tau_dot_perfect_measurements_ZOH_wind.m
+++ b/ode_comp_tau_dot_perfect_measurements_ZOH_wind.m
@@ -29,7 +29,7 @@ desired_dux = desired_ux - state(uxind);
 dydt(uxind) = desired_dux;
 desired_uy = 0; %parameters.K_ventral * (observations(omega_y_ind)- parameters.ref_omega_y);
 desired_duy = desired_uy - state(uyind);
-dydt(uyind) = desired_uy;
+dydt(uyind) = desired_duy;
 
 % z-axis dynamics / control:
 % omega_z = -state(vzind) / state(zind);

--- a/ode_comp_tau_dot_perfect_measurements_wind.m
+++ b/ode_comp_tau_dot_perfect_measurements_wind.m
@@ -28,7 +28,7 @@ desired_dux = desired_ux - state(uxind);
 dydt(uxind) = desired_dux;
 desired_uy = 0; %parameters.K_ventral * (observations(omega_y_ind)- parameters.ref_omega_y);
 desired_duy = desired_uy - state(uyind);
-dydt(uyind) = desired_uy;
+dydt(uyind) = desired_duy;
 
 % z-axis dynamics / control:
 omega_z = -state(vzind) / state(zind);


### PR DESCRIPTION
It doesn't really change the program output because we don't do anything in x and y direction. But I think the equation should be:
````
dydt(uyind) = desired_duy;
````
instead of 
````
dydt(uyind) = desired_uy;
````